### PR TITLE
chore: ready libsodium just in case first time being called

### DIFF
--- a/contextual.api.crypto.ts
+++ b/contextual.api.crypto.ts
@@ -299,6 +299,7 @@ export class ContextualCryptoApi {
      * @returns true if signature is valid, false otherwise
      */
     async verifyWithPublicKey(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean> {
+        await ready // libsodium
         return crypto_sign_verify_detached(signature, message, publicKey)
     }
 


### PR DESCRIPTION
In case verify is being called before anything else, make sure libsodium is loaded and ready